### PR TITLE
Making changes to make sdk sel 3 compatible

### DIFF
--- a/src/main/java/io/percy/selenium/Percy.java
+++ b/src/main/java/io/percy/selenium/Percy.java
@@ -169,6 +169,15 @@ public class Percy {
         postSnapshot(domSnapshot, name, driver.getCurrentUrl(), options);
     }
 
+    public boolean isTracedCommandExecutor() {
+        try {
+            Class.forName("org.openqa.selenium.remote.TracedCommandExecutor");
+            return true;
+        } catch (final ClassNotFoundException e) {
+            return false;
+        }
+    }
+
     /**
      * Take a snapshot and upload it to Percy.
      *
@@ -198,7 +207,7 @@ public class Percy {
         CommandExecutor executor = ((RemoteWebDriver) driver).getCommandExecutor();
 
         // Get HttpCommandExecutor From TracedCommandExecutor
-        if (executor instanceof TracedCommandExecutor) {
+        if (isTracedCommandExecutor()) {
             Class className = executor.getClass();
             try {
                 Field field = className.getDeclaredField("delegate");


### PR DESCRIPTION
Making changes to support selenium 3.141.59 as well. `TracedCommandExecutor` was added in selenium 4.0, we already had the code for backward compatibility however since the class doesn't exist the compatibility also failed