### PR TITLE
Migrate publishing from OSSRH to Maven Central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         java-version: 8
         distribution: 'adopt'
-        server-id: ossrh # Value of the distributionManagement/repository/id field of the pom.xml
+        server-id: central # Value of the distributionManagement/repository/id field of the pom.xml
         server-username: MAVEN_USERNAME # env variable for username in deploy
         server-password: MAVEN_PASSWORD # env variable for token in deploy
         gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }} # Value of the GPG private key to import

--- a/pom.xml
+++ b/pom.xml
@@ -92,12 +92,12 @@
 
   <distributionManagement>
     <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <id>central</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots</url>
     </snapshotRepository>
     <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <id>central</id>
+      <url>https://central.sonatype.com/</url>
     </repository>
   </distributionManagement>
 
@@ -184,15 +184,13 @@
         <version>3.0.0</version>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.13</version>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.9.0</version>
         <extensions>true</extensions>
         <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <!-- set to 'false' if you want to manually inspect the repository before releasing -->
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+          <publishingServerId>central</publishingServerId>
+          <autoPublish>true</autoPublish>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
This pull request updates the Maven project configuration to use the new Sonatype Central infrastructure for publishing releases, replacing the older OSSRH (OSS Repository Hosting) endpoints and plugins. The changes ensure that artifacts are deployed to the correct repository and use the latest publishing tools.

Repository and deployment configuration updates:

* Updated the `distributionManagement` section in `pom.xml` to use the new `central` repository IDs and URLs for both releases and snapshots, replacing all references to `ossrh` and its URLs.
* Changed the Maven publishing workflow in `.github/workflows/release.yml` to use the `central` server ID instead of `ossrh`.

Publishing plugin migration:

* Replaced the deprecated `nexus-staging-maven-plugin` with the new `central-publishing-maven-plugin` in `pom.xml`, updating group ID, artifact ID, version, and plugin configuration to match the new publishing process.