### PR TITLE
chore: bump version to 2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.percy</groupId>
   <artifactId>percy-java-selenium</artifactId>
-  <version>2.1.2</version>
+  <version>2.2.0</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
## Summary
- Bump version from 2.1.2 to 2.2.0 for Cucumber support release

🤖 Generated with [Claude Code](https://claude.com/claude-code)