### PR TITLE
release 2.2.1-beta.0 (PER-7348)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.percy</groupId>
   <artifactId>percy-java-selenium</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-beta.0</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>
@@ -32,7 +32,7 @@
     <connection>scm:git:git://github.com/percy/percy-java-selenium.git</connection>
     <developerConnection>scm:git:https://github.com/percy/percy-java-selenium.git</developerConnection>
     <url>https://github.com/percy/percy-java-selenium/tree/master</url>
-    <tag>v2.1.2</tag>
+    <tag>v2.2.1-beta.0</tag>
   </scm>
 
   <properties>

--- a/src/main/java/io/percy/selenium/Environment.java
+++ b/src/main/java/io/percy/selenium/Environment.java
@@ -10,7 +10,7 @@ import org.openqa.selenium.WrapsDriver;
  */
 class Environment {
   private WebDriver driver;
-  private final static String SDK_VERSION = "2.1.2";
+  private final static String SDK_VERSION = "2.2.1-beta.0";
   private final static String SDK_NAME = "percy-java-selenium";
 
   private String clientInfoOverride;


### PR DESCRIPTION
Beta release shipping the **PER-7348 readiness gate** (`waitForReady` before serialize), merged in #308.

### Version bump → `2.2.1-beta.0`
- `pom.xml` — `<version>` and `<scm><tag>`
- `src/main/java/io/percy/selenium/Environment.java` — `SDK_VERSION`

Ships with `@percy/cli@^1.31.15-beta.0` (readiness-capable CLI). Follows the same beta-release flow used for the other PER-7348 SDKs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)