### PR TITLE
release v2.2.1-beta.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.percy</groupId>
   <artifactId>percy-java-selenium</artifactId>
-  <version>2.2.1-beta.0</version>
+  <version>2.2.1-beta.1</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/io/percy/selenium/Environment.java
+++ b/src/main/java/io/percy/selenium/Environment.java
@@ -10,7 +10,7 @@ import org.openqa.selenium.WrapsDriver;
  */
 class Environment {
   private WebDriver driver;
-  private final static String SDK_VERSION = "2.2.1-beta.0";
+  private final static String SDK_VERSION = "2.2.1-beta.1";
   private final static String SDK_NAME = "percy-java-selenium";
 
   private String clientInfoOverride;


### PR DESCRIPTION
Bumps the SDK to the next beta (`2.2.1-beta.0` → `2.2.1-beta.1`) for a beta release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)