### PR TITLE
chore: release 2.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.percy</groupId>
   <artifactId>percy-java-selenium</artifactId>
-  <version>2.2.1-beta.1</version>
+  <version>2.2.1</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
Promotes the PER-8053 config-merge work from `2.2.1-beta.1` to stable `2.2.1`. Config is deep-merged into serializeDOM (per-call priority); verified via the cross-SDK sanity sweep.